### PR TITLE
GlobalKey needed StatefulWidget

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -21,8 +21,14 @@ Widget build(BuildContext context) {
 #### Snap with a Key
 ```dart
 
-class MyWidget extends StatelessWidget {
+class MyWidget extends StatefulWidget {
+  @override
+  _MyWidgetState createState() => _MyWidgetState();
+}
+
+class _MyWidgetState extends State<MyWidget> {
   final key = GlobalKey<SnappableState>();
+
   @override
   Widget build(BuildContext context) {
     return Snappable(
@@ -44,7 +50,7 @@ class MyWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Snappable(
-      snapOntap: true,
+      snapOnTap: true,
       child: Text('This whill be snapped'),
     );
   }


### PR DESCRIPTION
Needed the MyWidget example for snap with key to be stateful widget. It was giving an error that `currentState` was not a method of key.

The docs for GlobalKey(https://api.flutter.dev/flutter/widgets/GlobalKey-class.html) says it only extends stateful widgets, i.e.

```
GlobalKey<T extends State<StatefulWidget>> class
```

Also, small typo of CamelCase on `snapOnTap`